### PR TITLE
Correcting typo in bundle exec command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is the code set for [Going Serverless With Firebase](https://bigmachine.io/
 To install Middleman, navigate to the `1_start_here` directory and run:
 
 ```
-bundle install --path-vendor
+bundle install --path=vendor
 ```
 
 This will install the needed gems. You'll also need to install the Node modules using `npm install`.


### PR DESCRIPTION
I was following along and noticed the --path command had a `-` instead of a `=`. Tripped me up since I was copying and pasting but maybe wouldn't trip up others.